### PR TITLE
 fix rotation matrix with ground-plane (denorm)

### DIFF
--- a/show_tools/show_2d3d_box.py
+++ b/show_tools/show_2d3d_box.py
@@ -129,11 +129,15 @@ def project_3d(p2, x3d, y3d, z3d, w3d, h3d, l3d, ry3d, de_norm):
     # bounding box in object co-ordinate
     corners_3d = np.array([x_corners, y_corners, z_corners])
 
-    # rotate
-    corners_3d = R.dot(corners_3d)
-    R2 = np.array([[1, 0, 0],
-                   [0, -de_norm[1], +de_norm[2]],
-                   [0, -de_norm[2], -de_norm[1]]])
+    # get the rotation matrix from ground plane equation
+    a, b, c = - de_norm[0], - de_norm[2], - de_norm[3]
+    r12, r22, r32 = a, b, c
+    r11, r21, r31 = 1, - a / b, 0
+    div = a ** 2 + b ** 2
+    r13, r23, r33 = (- a * c) / div, (-b * c ) / div, 1
+    R2 = np.array([[r11, r12, r13], [r21, r22, r23], [r31, r32, r33]], dtype=np.float32)
+    R2 = R2 / np.linalg.norm(R2, axis=0)
+    
     corners_3d = R2.dot(corners_3d)
     # translate
     corners_3d += np.array([x3d, y3d, z3d]).reshape((3, 1))


### PR DESCRIPTION
A more general rotation matrix calculated from ground plane equation. With the ground plane, rotation around the three axis all can be calibrated. For more details, you can also refer to the [Rope3D-Toolkit](https://github.com/FlorinShum/Rope3D-Toolkit) maintained by me.

With the original version:
![original](https://user-images.githubusercontent.com/44775545/175128856-5d968f73-0bee-4c0c-898b-e95116f51bec.JPG)

With the revised version:
![revised](https://user-images.githubusercontent.com/44775545/175128892-86614d0c-f658-4948-9c32-c58f2a4ed978.jpg)

